### PR TITLE
feat: add cli-arg to expose coverage metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ _papers-please_ can be used alongside [husky](https://typicode.github.io/husky/#
 | --statementCoverageThreshold | number  | Statement coverage threshold for new files (in percentage)                                                                                 | 80                               |
 | --help                       | boolean | Show usage and available options                                                                                                           | false                            |
 | --verbose                    | boolean | Show verbose output for each step                                                                                                          | false                            |
-| --exposeMetrics              | boolean | Exposes coverage metrics for the modified/added files which matches the glob pattern                                                       | false                            |
+| --exposeMetrics              | boolean | Exposes coverage metrics into a json file for the modified/added files which matches the glob pattern                                                       | false                            |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ _papers-please_ can be used alongside [husky](https://typicode.github.io/husky/#
 | --statementCoverageThreshold | number  | Statement coverage threshold for new files (in percentage)                                                                                 | 80                               |
 | --help                       | boolean | Show usage and available options                                                                                                           | false                            |
 | --verbose                    | boolean | Show verbose output for each step                                                                                                          | false                            |
+| --exposeMetrics              | boolean | Exposes coverage metrics for the modified/added files which matches the glob pattern                                                       | false                            |
 
 ## Contributing
 

--- a/src/cliOptions.ts
+++ b/src/cliOptions.ts
@@ -68,6 +68,12 @@ export const CLI_OPTIONS = [
         valueKey: 'verbose',
         valueType: 'boolean',
     },
+    {
+        defaultValue: false,
+        description: 'Export coverage to a json file',
+        valueKey: 'exposeMetrics',
+        valueType: 'boolean',
+    },
 ] as const;
 
 export type CLIOptionNames = ArrayElement<typeof CLI_OPTIONS>['valueKey'];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,21 @@
 export const MODIFIED_FILE_FILTER = 'M';
 export const NEW_FILE_FILTER = 'A';
+
+export const DEFAULT_METRIC_VALUE = {
+    name: {
+        text: 'Name',
+        type: 'string',
+    },
+    missed: {
+        text: 'Missed',
+        type: 'integer',
+    },
+    covered: {
+        text: 'Covered',
+        type: 'integer',
+    },
+    percentage: {
+        text: 'Percentage',
+        type: 'float',
+    },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,3 +9,10 @@ export type CoverageFailureData = {
     lines: number;
     statements: number;
 };
+
+export type StatsFieldDataType = {
+    total: number;
+    covered: number;
+    skipped: number;
+    pct: number;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,23 @@ export type CoverageFailureData = {
     statements: number;
 };
 
-export type StatsFieldDataType = {
-    total: number;
-    covered: number;
-    skipped: number;
-    pct: number;
+export type MetricFieldData = Record<'total' | 'covered' | 'skipped' | 'pct', number>;
+
+export type CoverageMetricsData = {
+    lines: MetricFieldData;
+    functions: MetricFieldData;
+    branches: MetricFieldData;
+    name: string;
+};
+
+type CommonCoverageInfoField = Record<'text' | 'type', string>;
+
+type LineBranchMethodDataType = Record<
+    'missed' | 'covered' | 'percentage',
+    CommonCoverageInfoField & { value: number }
+>;
+
+export type CoverageModuleData = {
+    name: CommonCoverageInfoField & { value: string };
+    stats: Record<'line' | 'branch' | 'method', LineBranchMethodDataType>;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -326,7 +326,5 @@ export function exposeCoverageMetrics(coverageMetrics: CoverageMetricsData[], pr
         modules: moduleData,
     };
 
-    fs.writeFile(`${projectRoot}/coverage-metrics.json`, JSON.stringify(coverageReportData), (err) => {
-        if (err) throw err;
-    });
+    fs.writeFileSync(`${projectRoot}/coverage-metrics.json`, JSON.stringify(coverageReportData));
 }


### PR DESCRIPTION
### _Added argument_ - **exposeMetrics**.
> For the modified/added files which matches the glob pattern it exposes coverage metrics into a json file.

`yarn papers-please --trackGlobs="**/src/**/*.js" --exposeMetrics="true"`